### PR TITLE
API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 test-db/
+test-db-*/
 coverage
 node_modules/
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+test-db/
 coverage
 node_modules/
 *.log

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var PouchDB = require('pouchdb')
+PouchDB.plugin(require('pouchdb-hoodie-api'))
 
 module.exports = Store
 
@@ -10,4 +11,7 @@ function Store (dbName, options) {
   options = options || {}
 
   this.db = new PouchDB(dbName, options)
+
+  return this.db.hoodieApi()
 }
+

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "zuul": "^3.0.0"
   },
   "dependencies": {
-    "pouchdb": "^3.6.0"
+    "pouchdb": "^3.6.0",
+    "pouchdb-hoodie-api": "^1.1.0"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,3 +1,4 @@
 'use strict'
 
 require('./specs/constructor')
+require('./specs/api')

--- a/tests/specs/api.js
+++ b/tests/specs/api.js
@@ -1,0 +1,25 @@
+'use strict'
+
+var test = require('tape')
+
+var Store = require('../../')
+
+test('has "api" methods', function (t) {
+  t.plan(12)
+
+  var store = new Store('test-db')
+
+  t.is(typeof store.add, 'function', 'has "add" method')
+  t.is(typeof store.find, 'function', 'has "find" method')
+  t.is(typeof store.findOrAdd, 'function', 'has "findOrAdd" method')
+  t.is(typeof store.findAll, 'function', 'has "findAll" method')
+  t.is(typeof store.update, 'function', 'has "update" method')
+  t.is(typeof store.updateOrAdd, 'function', 'has "updateOrAdd" method')
+  t.is(typeof store.updateAll, 'function', 'has "updateAll" method')
+  t.is(typeof store.remove, 'function', 'has "remove" method')
+  t.is(typeof store.removeAll, 'function', 'has "removeAll" method')
+  t.is(typeof store.on, 'function', 'has "on" method')
+  t.is(typeof store.one, 'function', 'has "one" method')
+  t.is(typeof store.off, 'function', 'has "off" method')
+})
+


### PR DESCRIPTION
fixes #3 as well as exposes all the db methods from `pouchdb-hoodie-api`

The tests check that all the `api` methods exist on the `store` object.
- [x] `.add()`
- [x] `.find()`
- [x] `.findOrAdd()`
- [x] `.findAll()`
- [x] `.update()`
- [x] `.updateOrAdd()`
- [x] `.updateAll()`
- [x] `.remove()`
- [x] `.removeAll()`

Would love some constructive feedback. :)
