### PR TITLE
Unsynced-Local-Docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,14 @@
 var PouchDB = process.browser ? global.PouchDB : require('pouchdb')
 var API = require('pouchdb-hoodie-api')
 var Sync = require('pouchdb-hoodie-sync')
+var UnsyncedLocalDocs = require('pouchdb-hoodie-unsynced-local-docs')
 var merge = require('lodash.merge')
 var EventEmitter = require('events').EventEmitter
 
 PouchDB.plugin({
   hoodieApi: API.hoodieApi,
-  hoodieSync: Sync.hoodieSync
+  hoodieSync: Sync.hoodieSync,
+  unsyncedLocalDocs: UnsyncedLocalDocs.unsyncedLocalDocs
 })
 
 module.exports = Store
@@ -22,8 +24,27 @@ function Store (dbName, options) {
   var CustomPouchDB = PouchDB.defaults(options)
   var db = new CustomPouchDB(dbName)
   var emitter = new EventEmitter()
-  var api = merge(db.hoodieSync({remote: dbName + '-remote', emitter: emitter}), db.hoodieApi({emitter: emitter}))
+  var api = merge(
+    db.hoodieSync({remote: dbName + '-remote', emitter: emitter}),
+    db.hoodieApi({emitter: emitter}),
+    {
+      unsyncedLocalDocs: mapUnsyncedLocalIds.bind(db, db.unsyncedLocalDocs)
+    }
+  )
 
   return api
+}
+
+function mapUnsyncedLocalIds (unsyncedLocalDocs, options) {
+  return unsyncedLocalDocs.call(this, options)
+
+  .then(function (changedDocs) {
+    return changedDocs.map(function (doc) {
+      doc.id = doc._id
+      delete doc._id
+
+      return doc
+    })
+  })
 }
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lodash.merge": "^3.3.2",
     "pouchdb": "^3.6.0",
     "pouchdb-hoodie-api": "^1.2.1",
-    "pouchdb-hoodie-sync": "^1.1.0"
+    "pouchdb-hoodie-sync": "^1.1.0",
+    "pouchdb-hoodie-unsynced-local-docs": "^1.0.0"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -3,3 +3,4 @@
 require('./specs/constructor')
 require('./specs/api')
 require('./specs/sync')
+require('./specs/unsynced-local-docs')

--- a/tests/specs/unsynced-local-docs.js
+++ b/tests/specs/unsynced-local-docs.js
@@ -1,0 +1,50 @@
+'use strict'
+
+var test = require('tape')
+
+var Store = require('../../')
+var options = process.browser ? {
+  adapter: 'memory'
+} : {
+  db: require('memdown')
+}
+
+test('has "unsynced-local-docs" methods', function (t) {
+  t.plan(1)
+
+  var store = new Store('test-db-unsynced-local-docs', options)
+
+  t.is(typeof store.unsyncedLocalDocs, 'function', 'has "unsyncedLocalDocs" method')
+})
+
+test('returns docs with "id" prop', function (t) {
+  t.plan(5)
+
+  var store = new Store('test-db-ids', options)
+
+  var localObj1 = {id: 'test1', foo: 'bar1'}
+  var localObj2 = {id: 'test2', foo: 'bar2'}
+
+  store.add([localObj1, localObj2])
+
+  .then(function () {
+    return store.unsyncedLocalDocs({remote: 'test-db-ids-remote', keys: ''})
+  })
+
+  .then(function (changedDocs) {
+    t.is(changedDocs.length, 2, 'local changes detected, 2 docs')
+    t.ok(changedDocs[0].id, 'prop "id" exists')
+    t.is(changedDocs[0].foo, 'bar1', 'changedDocs[0].foo matches')
+    t.is(changedDocs[1].foo, 'bar2', 'changedDocs[1].foo matches')
+
+    return store.sync()
+  })
+
+  .then(function () {
+    return store.unsyncedLocalDocs({remote: 'test-db-ids-remote', keys: ''})
+  })
+
+  .then(function (changedDocs) {
+    t.is(changedDocs.length, 0, 'local changes synced with remote')
+  })
+})


### PR DESCRIPTION
This PR integrates the `pouchdb-hoodie-unsynced-local-docs` plugin into the `store` API and exposes it's method:
- [x] `unsyncedLocalDocs`
## TODO
- [x] initial feature implementation 
## Concerns

Could add fixes for #14 and #15 unless we want to leave those for smaller, starter contributions. 
## Issue

Fixes #8 
