### PR TITLE
Custom remote

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,9 @@ function Store (dbName, options) {
   var CustomPouchDB = PouchDB.defaults(options)
   var db = new CustomPouchDB(dbName)
   var emitter = new EventEmitter()
+  var remote = options.remote || dbName + '-remote'
   var api = merge(
-    db.hoodieSync({remote: dbName + '-remote', emitter: emitter}),
+    db.hoodieSync({remote: remote, emitter: emitter}),
     db.hoodieApi({emitter: emitter}),
     {
       findAllUnsynced: mapUnsyncedLocalIds.bind(db),

--- a/tests/specs/constructor.js
+++ b/tests/specs/constructor.js
@@ -58,3 +58,15 @@ test('constructs a store object without options', function (t) {
     })
   }
 })
+
+test('constructs a store object with remote option', function (t) {
+  t.plan(2)
+
+  var newOptions = options
+  newOptions.remote = 'custom-remote-name'
+
+  var store = new Store('test-db-remote-option', newOptions)
+
+  t.is(typeof store, 'object', 'is object')
+  t.is(store.db.__opts.remote, newOptions.remote, 'has correct remote name')
+})


### PR DESCRIPTION
This PR contains a test and feature implementation for passing a custom remote name as an option when creating a new `Store`. If no option is passed, then a default remote name is created using local name passed into `new Store()`, i.e. `name + '-remote'`. 
## Issues

Fixes #14 
