### PR TITLE
Store.defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-'use strict'
+module.exports = Store
 
 var PouchDB = global.PouchDB || require('pouchdb')
 var API = require('pouchdb-hoodie-api')
@@ -13,8 +13,6 @@ PouchDB.plugin({
   hoodieSync: Sync.hoodieSync,
   unsyncedLocalDocs: UnsyncedLocalDocs.unsyncedLocalDocs
 })
-
-module.exports = Store
 
 function Store (dbName, options) {
   if (!(this instanceof Store)) return new Store(dbName, options)
@@ -36,6 +34,19 @@ function Store (dbName, options) {
   subscribeToInternalEvents(emitter)
 
   return api
+}
+
+Store.defaults = function (defaultOpts) {
+  function CustomStore (dbName, options) {
+    if (typeof dbName !== 'string') throw new Error('Must be a valid string.')
+    options = options || {}
+
+    options = merge(defaultOpts, options)
+
+    return Store(dbName, options)
+  }
+
+  return CustomStore
 }
 
 function mapUnsyncedLocalIds (options) {

--- a/tests/specs/constructor.js
+++ b/tests/specs/constructor.js
@@ -70,3 +70,24 @@ test('constructs a store object with remote option', function (t) {
   t.is(typeof store, 'object', 'is object')
   t.is(store.db.__opts.remote, newOptions.remote, 'has correct remote name')
 })
+
+test('constructs a store object using "Store.defaults"', function (t) {
+  t.plan(2)
+
+  var CustomStore = Store.defaults(options)
+  var store = new CustomStore('test-db-custom')
+  var testDB = dbFactory('test-db-custom')
+  console.log(store)
+
+  t.ok(store.db, '.db exists')
+  t.is(store.db._db_name, testDB._db_name, '.db is PouchDB object')
+})
+
+test('"defaults" throws an error w/o db', function (t) {
+  t.plan(2)
+
+  var CustomStore = Store.defaults(options)
+
+  t.throws(CustomStore, 'no arguments')
+  t.notOk(CustomStore.db, 'db does not exist')
+})


### PR DESCRIPTION
This PR adds a `defaults` method to the `Store` constructor for users to create a custom `Store` with default options set. 

Fixes #15 
