### PR TITLE
Sync wrappers

### DIFF
--- a/lib/subscribe-to-internal-events.js
+++ b/lib/subscribe-to-internal-events.js
@@ -29,7 +29,7 @@ function markAsChanged (object) {
 
 function unmarkAsChanged (object) {
   var changedIds = localStorageWrapper.getObject('hoodie_changedObjectIds')
-  var id = object._id
+  var id = object.id
   var index = changedIds.indexOf(id)
 
   if (index === -1) {

--- a/lib/subscribe-to-sync-events.js
+++ b/lib/subscribe-to-sync-events.js
@@ -1,0 +1,18 @@
+module.exports = subscribeToSyncEvents
+
+var toObject = require('./utils/to-object')
+
+function subscribeToSyncEvents (syncApi, emmiter) {
+  syncApi.on('push', emitHoodieObject.bind(emmiter, 'push'))
+  syncApi.on('pull', emitHoodieObject.bind(emmiter, 'pull'))
+  syncApi.on('connect', emitHoodieObject.bind(emmiter, 'connect'))
+  syncApi.on('disconnect', emitHoodieObject.bind(emmiter, 'disconnect'))
+}
+
+function emitHoodieObject (event, object) {
+  if (object) {
+    this.emit(event, toObject(object))
+  } else {
+    this.emit(event)
+  }
+}

--- a/lib/sync-wrapper.js
+++ b/lib/sync-wrapper.js
@@ -1,0 +1,9 @@
+module.exports = syncWrapper
+
+var toObject = require('./utils/to-object')
+
+function syncWrapper (method, docsOrIds) {
+  return this[method](docsOrIds).then(function (syncedObjs) {
+    return syncedObjs.map(toObject)
+  })
+}

--- a/lib/utils/to-object.js
+++ b/lib/utils/to-object.js
@@ -1,0 +1,13 @@
+module.exports = toObject
+
+var merge = require('lodash.merge')
+
+function toObject (object) {
+  object = merge({
+    id: object._id
+  }, object)
+
+  delete object._id
+
+  return object
+}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "lodash.merge": "^3.3.2",
     "pouchdb": "^4.0.0",
     "pouchdb-hoodie-api": "1.4.0",
-    "pouchdb-hoodie-sync": "^1.1.0"
+    "pouchdb-hoodie-sync": "^1.2.0"
   }
 }

--- a/tests/specs/sync.js
+++ b/tests/specs/sync.js
@@ -21,8 +21,70 @@ test('has "sync" methods', function (t) {
   t.is(typeof store.isConnected, 'function', 'had "isConnected" method')
 })
 
+test('store.push() returns hoodie objects', function (t) {
+  t.plan(3)
+
+  var store = new Store('test-db-push-return', merge({remote: 'test-db-push-return-remote'}, options))
+  var obj1 = {id: 'test1', foo: 'bar1'}
+  var obj2 = {id: 'test2', foo: 'bar2'}
+
+  store.add([obj1, obj2])
+
+  .then(function () {
+    return store.push()
+  })
+
+  .then(function (pushedObjs) {
+    t.is(pushedObjs.length, 2, '2 items returned')
+    t.is(pushedObjs[0].id, 'test1', 'returns hoodie object')
+    t.is(pushedObjs[1].foo, 'bar2', 'returns hoodie object')
+  })
+})
+
+test('store.push(docsOrIds) returns hoodie objects', function (t) {
+  t.plan(3)
+
+  var store = new Store('test-db-push-objects-return', merge({remote: 'test-db-push-objects-return-remote'}, options))
+  var obj1 = {id: 'test1', foo: 'bar1'}
+  var obj2 = {id: 'test2', foo: 'bar2'}
+
+  store.add([obj1, obj2])
+
+  .then(function (addedObjs) {
+    return store.push(addedObjs)
+  })
+
+  .then(function (pushedObjs) {
+    t.is(pushedObjs.length, 2, '2 items returned')
+    t.is(pushedObjs[0].id, 'test1', 'returns hoodie object')
+    t.is(pushedObjs[1].foo, 'bar2', 'returns hoodie object')
+  })
+
+  .catch(console.warn.bind(console))
+})
+
+test('store.sync() returns hoodie objects', function (t) {
+  t.plan(3)
+
+  var store = new Store('test-db-sync-return', merge({remote: 'test-db-sync-return-remote'}, options))
+  var obj1 = {id: 'test1', foo: 'bar1'}
+  var obj2 = {id: 'test2', foo: 'bar2'}
+
+  store.add([obj1, obj2])
+
+  .then(function () {
+    return store.sync()
+  })
+
+  .then(function (pushedObjs) {
+    t.is(pushedObjs.length, 2, '2 items returned')
+    t.is(pushedObjs[0].id, 'test1', 'returns hoodie object')
+    t.is(pushedObjs[1].foo, 'bar2', 'returns hoodie object')
+  })
+})
+
 test('store.on("push") for store.push()', function (t) {
-  t.plan(2)
+  t.plan(3)
 
   var store = new Store('test-db-push', merge({remote: 'test-db-push-remote'}, options))
   var pushEvents = []
@@ -37,6 +99,7 @@ test('store.on("push") for store.push()', function (t) {
 
   .then(function () {
     t.is(pushEvents.length, 1, 'triggers 1 push event')
+    t.is(pushEvents[0].id, 'test', 'event passes object')
     t.is(pushEvents[0].foo, 'bar', 'event passes object')
   })
 })
@@ -74,7 +137,7 @@ test('api.off("push")', function (t) {
 })
 
 test('api.one("push")', function (t) {
-  t.plan(3)
+  t.plan(4)
 
   var store = new Store('test-db-push-one', merge({remote: 'test-db-push-one-remote'}, options))
   var pushEvents = []
@@ -92,6 +155,7 @@ test('api.one("push")', function (t) {
 
   .then(function () {
     t.is(pushEvents.length, 1, 'triggers 1 push event')
+    t.is(pushEvents[0].id, 'test1', 'event passes object')
     t.is(pushEvents[0].foo, 'bar1', 'event passes object')
   })
 
@@ -101,5 +165,22 @@ test('api.one("push")', function (t) {
 
   .then(function () {
     t.is(pushEvents.length, 1, 'triggers no second push event')
+  })
+})
+
+test('api.on("connect") for api.connect()', function (t) {
+  t.plan(1)
+
+  var store = new Store('test-db-on-connect', merge({remote: 'test-db-on-connect-remote'}, options))
+  var numConnectEvents = 0
+
+  store.on('connect', function () {
+    numConnectEvents += 1
+  })
+
+  store.connect()
+
+  .then(function () {
+    t.is(numConnectEvents, 1, '"connect" event triggered')
   })
 })

--- a/tests/specs/sync.js
+++ b/tests/specs/sync.js
@@ -29,7 +29,7 @@ test('store.on("push") for store.push()', function (t) {
 
   store.on('push', pushEvents.push.bind(pushEvents))
 
-  store.db.put({_id: 'test', foo: 'bar'})
+  store.add({id: 'test', foo: 'bar'})
 
   .then(function () {
     return store.push()
@@ -52,10 +52,10 @@ test('api.off("push")', function (t) {
     pushEvents.push(doc)
   }
 
-  var obj1 = {_id: 'test1', foo1: 'bar1'}
-  var obj2 = {_id: 'test2', foo1: 'bar2'}
+  var obj1 = {id: 'test1', foo1: 'bar1'}
+  var obj2 = {id: 'test2', foo1: 'bar2'}
 
-  store.db.bulkDocs([obj1, obj2])
+  store.add([obj1, obj2])
 
   .then(function () {
     return store.push('test2')
@@ -81,10 +81,10 @@ test('api.one("push")', function (t) {
 
   store.one('push', pushEvents.push.bind(pushEvents))
 
-  var obj1 = {_id: 'test1', foo: 'bar1'}
-  var obj2 = {_id: 'test2', foo: 'bar2'}
+  var obj1 = {id: 'test1', foo: 'bar1'}
+  var obj2 = {id: 'test2', foo: 'bar2'}
 
-  store.db.bulkDocs([obj1, obj2])
+  store.add([obj1, obj2])
 
   .then(function () {
     return store.push()


### PR DESCRIPTION
Fixes #16 

Still working on how to wrap the `pouchdb-hoodie-sync` events to return Hoodie objects instead of PouchDB objects. 
