### PR TITLE
"change" events on pull

### DIFF
--- a/lib/subscribe-to-internal-events.js
+++ b/lib/subscribe-to-internal-events.js
@@ -3,8 +3,12 @@ module.exports = subscribeToInternalEvents
 var localStorageWrapper = require('humble-localstorage')
 
 function subscribeToInternalEvents (emitter) {
-  emitter.on('change', function (eventName, object) {
-    markAsChanged(object)
+  emitter.on('change', function (eventName, object, options) {
+    if (options && options.remote) {
+      unmarkAsChanged(object)
+    } else {
+      markAsChanged(object)
+    }
   })
 
   emitter.on('push', function (object) {
@@ -29,6 +33,10 @@ function markAsChanged (object) {
 
 function unmarkAsChanged (object) {
   var changedIds = localStorageWrapper.getObject('hoodie_changedObjectIds')
+  if (!Array.isArray(changedIds)) {
+    return
+  }
+
   var id = object.id
   var index = changedIds.indexOf(id)
 

--- a/lib/subscribe-to-sync-events.js
+++ b/lib/subscribe-to-sync-events.js
@@ -9,10 +9,29 @@ function subscribeToSyncEvents (syncApi, emmiter) {
   syncApi.on('disconnect', emitHoodieObject.bind(emmiter, 'disconnect'))
 }
 
-function emitHoodieObject (event, object) {
-  if (object) {
-    this.emit(event, toObject(object))
+function emitHoodieObject (event, doc) {
+  if (doc) {
+    var object = toObject(doc)
+    this.emit(event, object)
+
+    if (event === 'pull') {
+      var changeType = getChangeTypeFor(object)
+      this.emit('change', changeType, object, {remote: true})
+      this.emit(changeType, object, {remote: true})
+    }
   } else {
     this.emit(event)
   }
+}
+
+function getChangeTypeFor (object) {
+  if (object._deleted) {
+    return 'remove'
+  }
+
+  if (object._rev.slice(0, 2) === '1-') {
+    return 'add'
+  }
+
+  return 'update'
 }

--- a/tests/specs/api.js
+++ b/tests/specs/api.js
@@ -44,6 +44,8 @@ test('store.on("change") with adding one', function (t) {
     t.is(changeEvents[0].eventName, 'add', 'passes the event name')
     t.is(changeEvents[0].object.foo, 'bar', 'event passes object')
   })
+
+  .catch(t.fail)
 })
 
 test('store.off("add") with one add handler', function (t) {
@@ -68,6 +70,8 @@ test('store.off("add") with one add handler', function (t) {
   .then(function () {
     t.is(addEvents.length, 0, 'triggers no add event')
   })
+
+  .catch(t.fail)
 })
 
 test('store.one("add") with adding one', function (t) {
@@ -86,6 +90,8 @@ test('store.one("add") with adding one', function (t) {
     t.is(addEvents.length, 1, 'triggers 1 add event')
     t.is(addEvents[0].object.foo, 'bar', 'event passes object')
   })
+
+  .catch(t.fail)
 })
 
 function addEventToArray (array, object) {

--- a/tests/specs/has-local-changes.js
+++ b/tests/specs/has-local-changes.js
@@ -31,6 +31,8 @@ test('.hasLocalChanges()', function (t) {
   .then(function () {
     t.is(store.hasLocalChanges(), false, 'returns "false" after sync')
   })
+
+  .catch(t.fail)
 })
 
 test('.hasLocalChanges(filter)', function (t) {
@@ -47,12 +49,14 @@ test('.hasLocalChanges(filter)', function (t) {
     t.is(store.hasLocalChanges('test1'), true, 'returns "true" with id filter')
     t.is(store.hasLocalChanges({id: 'test2'}), true, 'returns "true" to with object filter')
 
-    store.clear()
-
-    .then(function () {
-      t.is(store.hasLocalChanges(), false, 'returns "false" after "clear"')
-    })
+    return store.clear()
   })
+
+  .then(function () {
+    t.is(store.hasLocalChanges(), false, 'returns "false" after "clear"')
+  })
+
+  .catch(t.fail)
 })
 
 test('.hasLocalChanges() after changing same object twice', function (t) {
@@ -71,6 +75,8 @@ test('.hasLocalChanges() after changing same object twice', function (t) {
     t.is(store.hasLocalChanges('test1'), true, 'returns "true" to after update')
     t.is(changedIds.length, 1, 'stores only unique ids in reference')
   })
+
+  .catch(t.fail)
 })
 
 test('.hasLocalChanges(unknownId)', function (t) {
@@ -80,10 +86,12 @@ test('.hasLocalChanges(unknownId)', function (t) {
 
   var localObj = {_id: 'pouchdb-put-doc', foo: 'bar1'}
 
-  return store.db.put(localObj)
+  store.db.put(localObj)
 
   .then(function () {
     t.is(store.hasLocalChanges('pouchdb-put-doc'), false, 'returns "false" to stored, but unreferenced object')
     t.is(store.hasLocalChanges('unknown-id'), false, 'returns "false" to unknown object')
   })
+
+  .catch(t.fail)
 })

--- a/tests/specs/sync.js
+++ b/tests/specs/sync.js
@@ -39,6 +39,8 @@ test('store.push() returns hoodie objects', function (t) {
     t.is(pushedObjs[0].id, 'test1', 'returns hoodie object')
     t.is(pushedObjs[1].foo, 'bar2', 'returns hoodie object')
   })
+
+  .catch(t.fail)
 })
 
 test('store.push(docsOrIds) returns hoodie objects', function (t) {
@@ -60,7 +62,7 @@ test('store.push(docsOrIds) returns hoodie objects', function (t) {
     t.is(pushedObjs[1].foo, 'bar2', 'returns hoodie object')
   })
 
-  .catch(console.warn.bind(console))
+  .catch(t.fail)
 })
 
 test('store.sync() returns hoodie objects', function (t) {
@@ -81,6 +83,8 @@ test('store.sync() returns hoodie objects', function (t) {
     t.is(pushedObjs[0].id, 'test1', 'returns hoodie object')
     t.is(pushedObjs[1].foo, 'bar2', 'returns hoodie object')
   })
+
+  .catch(t.fail)
 })
 
 test('store.on("push") for store.push()', function (t) {
@@ -102,6 +106,8 @@ test('store.on("push") for store.push()', function (t) {
     t.is(pushEvents[0].id, 'test', 'event passes object')
     t.is(pushEvents[0].foo, 'bar', 'event passes object')
   })
+
+  .catch(t.fail)
 })
 
 test('api.off("push")', function (t) {
@@ -134,6 +140,8 @@ test('api.off("push")', function (t) {
   .then(function () {
     t.is(pushEvents.length, 1, 'push event was removed')
   })
+
+  .catch(t.fail)
 })
 
 test('api.one("push")', function (t) {
@@ -166,6 +174,8 @@ test('api.one("push")', function (t) {
   .then(function () {
     t.is(pushEvents.length, 1, 'triggers no second push event')
   })
+
+  .catch(t.fail)
 })
 
 test('api.on("connect") for api.connect()', function (t) {
@@ -183,4 +193,6 @@ test('api.on("connect") for api.connect()', function (t) {
   .then(function () {
     t.is(numConnectEvents, 1, '"connect" event triggered')
   })
+
+  .catch(t.fail)
 })


### PR DESCRIPTION
The current `store` API only triggers change events when calling its
methods like `store.add`, `store.update`, `store.remove` etc.

But if a change gets pulled from remote, no such event gets triggered.

This is WIP, the test in aa2359d illustrates the problem
