### PR TITLE
Scoped stores emit events on type change

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,13 @@ function Store (dbName, options) {
     objectTypeById: {}
   }
 
+  // possible race condition...
+  storeApi.findAll().then(function (objects) {
+    objects.forEach(function (object) {
+      state.objectTypeById[object.id] = object.type
+    })
+  })
+
   var api = merge(
     scoped.bind(null, state, storeApi),
     storeApi,

--- a/index.js
+++ b/index.js
@@ -44,8 +44,12 @@ function Store (dbName, options) {
   var syncApi = db.hoodieSync({remote: remote})
   var storeApi = db.hoodieApi({emitter: emitter})
 
+  var state = {
+    objectTypeById: {}
+  }
+
   var api = merge(
-    scoped.bind(null, storeApi),
+    scoped.bind(null, state, storeApi),
     storeApi,
     {
       hasLocalChanges: hasLocalChanges.bind(db),

--- a/lib/scoped/index.js
+++ b/lib/scoped/index.js
@@ -1,9 +1,8 @@
 module.exports = scoped
 
 var EventEmitter = require('events').EventEmitter
-var map = require('lodash.map')
 
-function scoped (api, type) {
+function scoped (state, api, type) {
   var emitter = new EventEmitter()
 
   var scopedApi = {
@@ -33,11 +32,14 @@ function scoped (api, type) {
     }
   }
 
-  var state = {
-    storeObjectIds: map(scopedApi.findAll(), function (object) {
-      return object.id
+  // possible race condition... if for some reason this didn't resolve before
+  // a remote change got pulled in, add/remove/change events wouldn't fire.
+  // seems unlikely, but, still...
+  scopedApi.findAll().then(function (objects) {
+    objects.forEach(function (object) {
+      state.objectTypeById[object.id] = object.type
     })
-  }
+  })
 
   api.on('change', require('../utils/handle-type-change').bind(null, state, emitter, type))
 

--- a/lib/scoped/index.js
+++ b/lib/scoped/index.js
@@ -1,6 +1,7 @@
 module.exports = scoped
 
 var EventEmitter = require('events').EventEmitter
+var map = require('lodash.map')
 
 function scoped (api, type) {
   var emitter = new EventEmitter()
@@ -32,8 +33,13 @@ function scoped (api, type) {
     }
   }
 
-  api.on('change', require('../utils/handle-type-change').bind(null, emitter, type))
+  var state = {
+    storeObjectIds: map(scopedApi.findAll(), function (object) {
+      return object.id
+    })
+  }
+
+  api.on('change', require('../utils/handle-type-change').bind(null, state, emitter, type))
 
   return scopedApi
 }
-

--- a/lib/scoped/index.js
+++ b/lib/scoped/index.js
@@ -32,15 +32,6 @@ function scoped (state, api, type) {
     }
   }
 
-  // possible race condition... if for some reason this didn't resolve before
-  // a remote change got pulled in, add/remove/change events wouldn't fire.
-  // seems unlikely, but, still...
-  scopedApi.findAll().then(function (objects) {
-    objects.forEach(function (object) {
-      state.objectTypeById[object.id] = object.type
-    })
-  })
-
   api.on('change', require('../utils/handle-type-change').bind(null, state, emitter, type))
 
   return scopedApi

--- a/lib/utils/handle-type-change.js
+++ b/lib/utils/handle-type-change.js
@@ -1,9 +1,20 @@
 module.exports = handleTypeChange
 
-function handleTypeChange (emitter, type, eventName, object) {
+function handleTypeChange (state, emitter, type, eventName, object) {
+  var stateIndex = state.storeObjectIds.indexOf(object.id)
+
   if (object.type === type) {
     emitter.emit(eventName + ':' + type, object)
     emitter.emit('change:' + type, eventName, object)
+
+    if (stateIndex === -1) {
+      state.storeObjectIds.push(object.id)
+      emitter.emit('add:' + type, object)
+    }
+  } else {
+    if (stateIndex > -1) {
+      state.storeObjectIds.splice(stateIndex, 1)
+      emitter.emit('remove:' + type, {id: object.id, type: type})
+    }
   }
 }
-

--- a/lib/utils/handle-type-change.js
+++ b/lib/utils/handle-type-change.js
@@ -11,7 +11,7 @@ function handleTypeChange (state, emitter, type, eventName, object) {
     state.objectTypeById[object.id] = type
     emitter.emit('add:' + type, object)
   }
-  if (isScopeType) {
+  if (isScopeType || wasScopeType) {
     emitter.emit(eventName + ':' + type, object)
     emitter.emit('change:' + type, eventName, object)
   }

--- a/lib/utils/handle-type-change.js
+++ b/lib/utils/handle-type-change.js
@@ -1,20 +1,18 @@
 module.exports = handleTypeChange
 
 function handleTypeChange (state, emitter, type, eventName, object) {
-  var stateIndex = state.storeObjectIds.indexOf(object.id)
+  var wasScopeType = state.objectTypeById[object.id] === type
+  var isScopeType = object.type === type
 
-  if (object.type === type) {
+  if (wasScopeType && !isScopeType) {
+    emitter.emit('remove:' + type, {id: object.id, type: type})
+  }
+  if (!wasScopeType && isScopeType) {
+    state.objectTypeById[object.id] = type
+    emitter.emit('add:' + type, object)
+  }
+  if (isScopeType) {
     emitter.emit(eventName + ':' + type, object)
     emitter.emit('change:' + type, eventName, object)
-
-    if (stateIndex === -1) {
-      state.storeObjectIds.push(object.id)
-      emitter.emit('add:' + type, object)
-    }
-  } else {
-    if (stateIndex > -1) {
-      state.storeObjectIds.splice(stateIndex, 1)
-      emitter.emit('remove:' + type, {id: object.id, type: type})
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "hoodie-zuul-config": "^2.0.0",
     "humble-localstorage": "^1.4.2",
+    "lodash.map": "^3.1.4",
     "lodash.merge": "^3.3.2",
     "pouchdb": "^5.1.0",
     "pouchdb-hoodie-api": "^1.6.0",

--- a/tests/specs/scoped.js
+++ b/tests/specs/scoped.js
@@ -495,9 +495,8 @@ test('scoped Store .off()', function (t) {
   })
 })
 
-// https://github.com/hoodiehq/hoodie-client-store/issues/45
-test.skip('when type change', function (t) {
-  t.plan(6)
+test('when type change', function (t) {
+  t.plan(8)
 
   var store = new Store('test-db-type-change', merge({remote: 'test-db-type-change'}, options))
   var scopedStoreOldType = store('oldtype')
@@ -506,12 +505,23 @@ test.skip('when type change', function (t) {
 
   .then(function () {
     scopedStoreOldType.on('remove', function (object) {
+      scopedStoreOldType
+      .find(object.id)
+      .catch(t.throws)
+
       t.is(object.type, 'oldtype', 'in remove event on scopedStoreOldType, type is "oldtype"')
       t.is(object.foo, undefined, 'in remove event on scopedStoreOldType, foo is undefined')
     })
     scopedStoreNewType.on('add', function (object) {
-      t.is(object.type, 'newtype', 'in remove event on scopedStoreNewType, type is newtype')
-      t.is(object.foo, 'bar', 'in remove event on scopedStoreNewType, foo is bar')
+      scopedStoreNewType
+      .find(object.id)
+      .then(function (foundObj) {
+        t.deepEqual(foundObj, object, 'in add event on scopedStoreNewType, object is present in store')
+      })
+      .catch(t.fail)
+
+      t.is(object.type, 'newtype', 'in add event on scopedStoreNewType, type is newtype')
+      t.is(object.foo, 'bar', 'in add event on scopedStoreNewType, foo is bar')
     })
     store.on('update', function (object) {
       t.is(object.type, 'newtype', 'in update event on global store, type is newtype')

--- a/tests/specs/scoped.js
+++ b/tests/specs/scoped.js
@@ -496,7 +496,7 @@ test('scoped Store .off()', function (t) {
 })
 
 test('when type change', function (t) {
-  t.plan(8)
+  t.plan(10)
 
   var store = new Store('test-db-type-change', merge({remote: 'test-db-type-change'}, options))
   var scopedStoreOldType = store('oldtype')
@@ -512,6 +512,10 @@ test('when type change', function (t) {
       t.is(object.type, 'oldtype', 'in remove event on scopedStoreOldType, type is "oldtype"')
       t.is(object.foo, undefined, 'in remove event on scopedStoreOldType, foo is undefined')
     })
+    scopedStoreOldType.on('change', function (object) {
+      t.assert(true, 'scopedStoreOldType fired change event on remove')
+    })
+
     scopedStoreNewType.on('add', function (object) {
       scopedStoreNewType
       .find(object.id)
@@ -523,6 +527,10 @@ test('when type change', function (t) {
       t.is(object.type, 'newtype', 'in add event on scopedStoreNewType, type is newtype')
       t.is(object.foo, 'bar', 'in add event on scopedStoreNewType, foo is bar')
     })
+    scopedStoreNewType.on('change', function (object) {
+      t.assert(true, 'scopedStoreNewType fired change event on remove')
+    })
+
     store.on('update', function (object) {
       t.is(object.type, 'newtype', 'in update event on global store, type is newtype')
       t.is(object.foo, 'bar', 'in update event on global store, foo is bar')


### PR DESCRIPTION
Here’s a first stab at this problem with a fairly simple solution:
- Maintain ~~state in each store~~ global state object and pass down to scoped stores
- During a sync push/pull, check state for objects which have changed type, emit add/remove events accordingly

Closes #45
