### PR TITLE
options.ajax

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ store = new Store(dbName, options)
 // Store.defaults({remoteBaseUrl: 'http://localhost:5984' })
 // store = new Store('mydb')
 
+// options.ajax: options or function that returns options to be passed to all replications
+
 // all methods return promises
 store.add(object)
 store.add([object1, id2])
@@ -107,7 +109,7 @@ Include this plugin in your HTML page:
 
 Since `pouchdb.js` is bundled into the plugin by default, there's no need to load it separately.
 If you want to load your own PouchDB, just add it before loading the plugin, and it'll use your version of `pouchdb.js`.  
-  
+
 ```html
 <script src="node_modules/pouchdb/dist/pouchdb.js"></script>
 ```

--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 module.exports = Store
 
-var API = require('pouchdb-hoodie-api')
 var EventEmitter = require('events').EventEmitter
+
 var merge = require('lodash.merge')
 var PouchDB = global.PouchDB || require('pouchdb')
-var Sync = require('pouchdb-hoodie-sync')
 
 var hasLocalChanges = require('./lib/has-local-changes')
 var subscribeToInternalEvents = require('./lib/subscribe-to-internal-events')
@@ -12,10 +11,8 @@ var subscribeToSyncEvents = require('./lib/subscribe-to-sync-events')
 var syncWrapper = require('./lib/sync-wrapper')
 var scoped = require('./lib/scoped/')
 
-PouchDB.plugin({
-  hoodieApi: API.hoodieApi,
-  hoodieSync: Sync.hoodieSync
-})
+PouchDB.plugin(require('pouchdb-hoodie-api'))
+PouchDB.plugin(require('pouchdb-hoodie-sync'))
 
 function Store (dbName, options) {
   if (!(this instanceof Store)) return new Store(dbName, options)
@@ -41,7 +38,7 @@ function Store (dbName, options) {
   var db = new CustomPouchDB(dbName)
   var emitter = new EventEmitter()
   var remote = options.remote
-  var syncApi = db.hoodieSync({remote: remote})
+  var syncApi = db.hoodieSync({remote: remote, ajax: options.ajax})
   var storeApi = db.hoodieApi({emitter: emitter})
 
   var api = merge(
@@ -76,4 +73,3 @@ Store.defaults = function (defaultOpts) {
 
   return CustomStore
 }
-

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "lodash.merge": "^3.3.2",
     "pouchdb": "^5.1.0",
     "pouchdb-hoodie-api": "^1.6.0",
-    "pouchdb-hoodie-sync": "^1.3.0"
+    "pouchdb-hoodie-sync": "^1.4.1"
   }
 }

--- a/tests/specs/constructor.js
+++ b/tests/specs/constructor.js
@@ -12,72 +12,72 @@ var options = process.browser ? {
 }
 
 test('new Store(db, options)', function (t) {
-  t.plan(3)
-
   var store = new Store('test-db', merge({remote: 'test-db-remote'}, options))
   var testDB = dbFactory('test-db')
 
   t.is(typeof store, 'function', 'is a constructor')
   t.ok(store.db, 'sets .db on instance')
   t.is(store.db._db_name, testDB._db_name, '.db is PouchDB object')
+
+  t.end()
 })
 
 test('Store(db, options) w/o new', function (t) {
-  t.plan(3)
-
   var store = Store('test-db', merge({remote: 'test-db-remote'}, options))
   var testDB = dbFactory('test-db')
 
   t.is(typeof store, 'function', 'is a constructor')
   t.ok(store.db, 'sets .db on instance')
   t.is(store.db._db_name, testDB._db_name, '.db is PouchDB object')
+
+  t.end()
 })
 
 test('new Store()', function (t) {
-  t.plan(1)
-
   t.throws(Store, 'throws error')
+
+  t.end()
 })
 
 test('new Store(dbName)', function (t) {
-  t.plan(1)
-
   t.throws(Store.bind(null, 'db'), 'throws error')
+
+  t.end()
 })
 
 test('new Store("name", {remote: "othername"})', function (t) {
-  t.plan(1)
-
   var store = new Store('name', merge({ remote: 'othername' }, options))
   t.is(store.db.__opts.remote, 'othername', 'sets remote name to "othername"')
+
+  t.end()
 })
 
 test('new Store("name", {remoteBaseUrl: "https://example.com"})', function (t) {
-  t.plan(1)
-
   var store = new Store('name', merge({ remoteBaseUrl: 'https://my.cou.ch' }, options))
   t.is(store.db.__opts.remote, 'https://my.cou.ch/name', 'sets remote name to "https://my.cou.ch/name"')
+
+  t.end()
 })
 
 test('remoteBaseUrl with trailing /', function (t) {
-  t.plan(1)
-
   var store = new Store('name', merge({ remoteBaseUrl: 'https://my.cou.ch/' }, options))
   t.is(store.db.__opts.remote, 'https://my.cou.ch/name', 'sets remote name without double //')
+
+  t.end()
 })
 
 test('new Store("name", {remote: "othername", remoteBaseUrl: "https://example.com"})', function (t) {
-  t.plan(1)
-
   var store = new Store('name', merge({ remote: 'othername', remoteBaseUrl: 'https://my.cou.ch' }, options))
   t.is(store.db.__opts.remote, 'https://my.cou.ch/othername', 'sets remote name to "https://my.cou.ch/othername"')
+
+  t.end()
 })
 
 test('new Store("name", {remote: "othername", remoteBaseUrl: "https://example.com"})', function (t) {
-  t.plan(1)
-
   var store = new Store('name', merge({ remote: 'https://my.other.cou.ch/name', remoteBaseUrl: 'https://my.cou.ch' }, options))
   t.is(store.db.__opts.remote, 'https://my.other.cou.ch/name', 'sets remote name to "https://my.cou.ch/othername"')
+
+  t.end()
 })
 
 test('constructs a store object without options.adapter / options.db', function (t) {
@@ -92,24 +92,24 @@ test('constructs a store object without options.adapter / options.db', function 
 })
 
 test('Store.defaults({remote})', function (t) {
-  t.plan(2)
-
   var CustomStore = Store.defaults(merge({remote: 'test-db-custom-remote'}, options))
   var store = new CustomStore('test-db-custom')
 
   t.throws(CustomStore, 'throws without argumens')
   t.is(store.db.__opts.remote, 'test-db-custom-remote', 'sets remote name')
+
+  t.end()
 })
 
 test('Store.defaults({remoteBaseUrl})', function (t) {
-  t.plan(2)
-
   var CustomStore = Store.defaults(merge({remoteBaseUrl: 'http://example.com'}, options))
   var store = new CustomStore('test-db-custom')
   var store2 = new CustomStore('test-db-custom2')
 
   t.is(store.db.__opts.remote, 'http://example.com/test-db-custom', 'sets remote name')
   t.is(store2.db.__opts.remote, 'http://example.com/test-db-custom2', 'sets remote name correcly on multiple instances')
+
+  t.end()
 })
 
 function cleanupDb (store, t) {


### PR DESCRIPTION
pass `options.ajax` from constructor to `.hoodieSync` API. `options.ajax` can be either an object or a function that returns ajax options. The latter allows us to set the `authorization` header to the bearer token with the current user’s session.id, which can be access via `account.get().session.id` (once https://github.com/hoodiehq/hoodie-client-account/pull/46 is merged)

More or less like this

``` js
hoodie.store = new Store('myDb', {
  ajax: function () {
    return {
      headers: 'Bearer ' + hoodie.account.get().session.id
    }
  }
})
```

The current version of this is probably implemented here:
https://github.com/hoodiehq/hoodie-client/blob/master/index.js
