### PR TITLE
Adds "reset" method

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function Store (dbName, options) {
     scoped.bind(null, state, storeApi),
     storeApi,
     {
-      hasLocalChanges: hasLocalChanges.bind(db),
+      hasLocalChanges: hasLocalChanges,
       push: syncWrapper.bind(syncApi, 'push'),
       pull: syncWrapper.bind(syncApi, 'pull'),
       sync: syncWrapper.bind(syncApi, 'sync'),
@@ -72,6 +72,8 @@ function Store (dbName, options) {
       isConnected: syncApi.isConnected
     }
   )
+
+  api.reset = require('./lib/reset').bind(null, dbName, CustomPouchDB, state, api, emitter, remote, ajaxOptions, PouchDB)
 
   subscribeToSyncEvents(syncApi, emitter)
   subscribeToInternalEvents(emitter)

--- a/lib/reset.js
+++ b/lib/reset.js
@@ -1,0 +1,45 @@
+module.exports = reset
+
+var merge = require('lodash/merge')
+
+var subscribeToSyncEvents = require('./subscribe-to-sync-events')
+var syncWrapper = require('./sync-wrapper')
+var scoped = require('./scoped/')
+
+function reset (dbName, CustomPouchDB, state, api, emitter, remote, ajaxOptions, PouchDB, options) {
+  if (options) {
+    if (options.name) {
+      dbName = options.name
+    }
+
+    if (options.remote) {
+      remote = options.remote
+    }
+
+    CustomPouchDB = PouchDB.defaults(options)
+  }
+
+  return api.clear()
+
+  .then(function () {
+    var newDB = new CustomPouchDB(dbName)
+    var syncApi = newDB.hoodieSync({remote: remote, ajax: ajaxOptions})
+    var storeApi = newDB.hoodieApi({emitter: emitter})
+
+    subscribeToSyncEvents(syncApi, emitter)
+
+    return merge(
+      api,
+      scoped.bind(null, state, storeApi),
+      storeApi,
+      {
+        push: syncWrapper.bind(syncApi, 'push'),
+        pull: syncWrapper.bind(syncApi, 'pull'),
+        sync: syncWrapper.bind(syncApi, 'sync'),
+        connect: syncApi.connect,
+        disconnect: syncApi.disconnect,
+        isConnected: syncApi.isConnected
+      }
+    )
+  })
+}

--- a/tests/specs/api.js
+++ b/tests/specs/api.js
@@ -94,6 +94,58 @@ test('store.one("add") with adding one', function (t) {
   .catch(t.fail)
 })
 
+test('store.reset creates empty instance of store', function (t) {
+  t.plan(3)
+
+  var store = new Store('test-db-clear', merge({remote: 'test-db-clear'}, options))
+  var addEvents = []
+  store.on('add', addEvents.push.bind(addEvents))
+  store.on('clear', t.pass.bind(null, '"clear" event emitted'))
+  store.reset()
+
+  .then(function () {
+    return store.findAll()
+  })
+
+  .then(function (result) {
+    t.deepEqual(result, [], '.findAll() resolves with empty array after .clear()')
+
+    return store.add({id: 'test', foo: 'bar'})
+  })
+
+  .then(function () {
+    t.is(addEvents.length, 1, 'triggers "add" event after "clear"')
+  })
+
+  .catch(t.fail)
+})
+
+test('store.reset creates empty instance of store with new options', function (t) {
+  t.plan(4)
+
+  var store = new Store('test-db-clear', merge({remote: 'test-db-clear'}, options))
+  var newOptions = {
+    name: 'new-test-db-clear',
+    remote: 'new-test-db-clear'
+  }
+  store.on('clear', t.pass.bind(null, '"clear" event emitted'))
+
+  // merge in-memory adapter options
+  store.reset(merge({}, options, newOptions))
+
+  .then(function () {
+    return store.findAll()
+  })
+
+  .then(function (result) {
+    t.deepEqual(result, [], '.findAll() resolves with empty array after .clear()')
+    t.is(store.db._db_name, newOptions.name, 'reset store has a new name')
+    t.is(store.db.__opts.remote, newOptions.remote, 'reset store has a new remote')
+  })
+
+  .catch(t.fail)
+})
+
 function addEventToArray (array, object) {
   if (arguments.length > 2) {
     arguments[0].push({

--- a/tests/specs/sync.js
+++ b/tests/specs/sync.js
@@ -322,3 +322,31 @@ test('triggers no "change" from remote if only local changes pushed', function (
 
   .catch(t.fail)
 })
+
+test('after "clear", store.on("push") for store.push()', function (t) {
+  t.plan(4)
+
+  var store = new Store('test-db-push', merge({remote: 'test-db-push-remote'}, options))
+  var pushEvents = []
+
+  store.on('push', pushEvents.push.bind(pushEvents))
+  store.on('clear', t.pass.bind(null, '"clear" event emitted'))
+
+  store.reset()
+
+  .then(function () {
+    return store.add({id: 'test', foo: 'bar'})
+  })
+
+  .then(function () {
+    return store.push()
+  })
+
+  .then(function () {
+    t.is(pushEvents.length, 1, 'triggers 1 push event')
+    t.is(pushEvents[0].id, 'test', 'event passes object')
+    t.is(pushEvents[0].foo, 'bar', 'event passes object')
+  })
+
+  .catch(t.fail)
+})


### PR DESCRIPTION
As mentioned in https://github.com/hoodiehq/hoodie-client/issues/43#issuecomment-170343186, a `reset` method has been added to the API for resolving with a usable database after destroying an old one. 

``` js
var Store = require('hoodie-client-store')

var newStore = new Store(/*options*/)

// do some store stuff

// reset the store
newStore.reset()

.then(function () {
  return newStore.findAll() // resolves successfully instead of throwing an Error
})

.then(function (results) {
  console.log(results) // returns an empty Array
})
```
