### PR TITLE
removeAll() rejects with error if no docs in scope

### DIFF
--- a/lib/scoped/remove-all.js
+++ b/lib/scoped/remove-all.js
@@ -7,6 +7,10 @@ function removeAll (type, api, filterFunction) {
   return findAll(type, api)
 
   .then(function (scopedObjects) {
+    if (scopedObjects.length === 0) {
+      return Promise.resolve(scopedObjects)
+    }
+
     return filterFunction ? remove(type, api, scopedObjects.filter(filterFunction)) : remove(type, api, scopedObjects)
   })
 }

--- a/tests/specs/scoped.js
+++ b/tests/specs/scoped.js
@@ -538,6 +538,21 @@ test('scoped Store .removeAll(filterFunction)', function (t) {
   .catch(t.fail)
 })
 
+test('.removeAll() with a non-existent scope returns empty list', function (t) {
+  t.plan(1)
+
+  var store = new Store('test-remove-all-bad-scope', merge({remote: 'test-remove-all-bad-scope'}, options))
+  var testStore = store('test')
+
+  return testStore.removeAll()
+
+  .then(function (removedItems) {
+    t.is(removedItems.length, 0, 'removedItems is empty')
+  })
+
+  .catch(t.fail)
+})
+
 test('scoped Store .one()', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
Calling `hoodie.store(scopeName).removeAll()` when there are no documents with type: scopeName results in an uncaught error `Items not found`.  This is due to the fact that in `removeAll()` we call `remove()` even if the list of returned objects is empty.  `remove()` eventually calls `find()` which then throws an `Items not found` error.

Instead, `hoodie.store(scopeName).removeAll()` should just return an empty list.  This change returns early if `findAll()` returns an empty list in `removeAll()`.

Closes #110.
