### PR TITLE
store('scope').update() should only update items in scope 'scope'

### DIFF
--- a/lib/scoped/update.js
+++ b/lib/scoped/update.js
@@ -1,11 +1,59 @@
 module.exports = update
 
 var find = require('./find')
+var merge = require('lodash/merge')
 
 function update (type, api, objectsOrIds, change) {
   return find(type, api, objectsOrIds)
 
   .then(function (storedObjects) {
-    return api.update(objectsOrIds, change)
+    // objectsOrIds may contain updated information for the respective storedObject
+    // (e.g. _deleted = true), so incorporate all information in the objectOrId into
+    // the storedObject
+    var updatedObjects = updateObjectsAndFilterErrors(objectsOrIds, storedObjects)
+
+    return api.update(updatedObjects, change)
+
+    .then(function (apiUpdates) {
+      if (!Array.isArray(apiUpdates)) {
+        return apiUpdates
+      }
+
+      return restoreOriginalFindErrors(storedObjects, apiUpdates)
+    })
+  })
+}
+
+function updateObjectsAndFilterErrors (objectsOrIds, storedObjects) {
+  if (!Array.isArray(objectsOrIds)) {
+    return updateObject(objectsOrIds, storedObjects)
+  }
+
+  return storedObjects.map(function (storedObject, index) {
+    if (storedObject instanceof Error) {
+      return storedObject
+    }
+
+    return updateObject(objectsOrIds[index], storedObject)
+  }).filter(function (storedObject) {
+    return !(storedObject instanceof Error)
+  })
+}
+
+function updateObject (objectOrId, storedObject) {
+  if (typeof objectOrId !== 'object') {
+    return storedObject
+  }
+
+  return merge(storedObject, objectOrId)
+}
+
+function restoreOriginalFindErrors (foundObjects, apiUpdates) {
+  return foundObjects.map(function (foundObject) {
+    if (foundObject instanceof Error) {
+      return foundObject
+    }
+
+    return apiUpdates.shift()
   })
 }

--- a/tests/specs/scoped.js
+++ b/tests/specs/scoped.js
@@ -334,6 +334,43 @@ test('scoped Store .update()', function (t) {
   })
 })
 
+test('scoped Store .update() updates the correct scope', function (t) {
+  t.plan(7)
+
+  var store = new Store('test-db-scoped-update', merge({remote: 'test-db-scoped-update'}, options))
+
+  var testItems = [
+    { foo: 'bar1', id: 'id1', type: 'test2' },
+    { foo: 'bar2', id: 'id2', type: 'test1' },
+    { foo: 'bar3', id: 'id3', type: 'test2' }
+  ]
+
+  store.add(testItems)
+
+  .then(function (items) {
+    return store('test2').update([
+      { id: 'id1', foo: 'bar20' },
+      { id: 'id2', foo: 'bar10' },
+      { id: 'id3', foo: 'bar100' }
+    ])
+  })
+
+  .then(function (newItem) {
+    t.is(newItem.length, 3, 'returns results for both items')
+
+    t.is(newItem[0].foo, 'bar20', 'returns updated testStore2 item')
+    t.is(newItem[0].type, 'test2', 'returns correctly typed item')
+
+    t.true(newItem[1] instanceof Error, 'returns error for item out of scope')
+    t.is(newItem[1].name, 'Not found', 'returns not found error')
+
+    t.is(newItem[2].foo, 'bar100', 'returns updated testStore2 item')
+    t.is(newItem[2].type, 'test2', 'returns correctly typed item')
+  })
+
+  .catch(t.fail)
+})
+
 test('scoped Store .updateOrAdd()', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
Currently, scope is currently ignored in the scoped `update` store method.  This change fixes store('scope').update() calls so that only those items in scope get updated.

Closes #114.
