### PR TITLE
find() should return 'Not found' for out of scope items

### DIFF
--- a/lib/scoped/find-or-add.js
+++ b/lib/scoped/find-or-add.js
@@ -38,24 +38,20 @@ function findOrAdd (type, api, idOrObjectOrArray, newObject) {
   })
 
   .catch(function () {
-    if (Array.isArray(idOrObjectOrArray)) {
-      newObject = idOrObjectOrArray
+    var id = toId(idOrObjectOrArray)
+
+    if (!id) {
+      throw new Error('Missing ID')
+    }
+
+    if (idOrObjectOrArray === id && !newObject) {
+      throw new Error('Missing ID')
+    }
+
+    if (typeof newObject === 'object') {
+      newObject.id = id
     } else {
-      var id = toId(idOrObjectOrArray)
-
-      if (!id) {
-        throw new Error('Missing ID')
-      }
-
-      if (idOrObjectOrArray === id && !newObject) {
-        throw new Error('Missing ID')
-      }
-
-      if (typeof newObject === 'object') {
-        newObject.id = id
-      } else {
-        newObject = idOrObjectOrArray
-      }
+      newObject = idOrObjectOrArray
     }
 
     return add(type, api, newObject)

--- a/lib/scoped/find.js
+++ b/lib/scoped/find.js
@@ -7,19 +7,25 @@ function find (type, api, objectsOrIds) {
 
   .then(function (storedObjects) {
     if (Array.isArray(storedObjects)) {
-      var typedObjects = storedObjects.filter(typeFilter.bind(null, type))
-
-      if (typedObjects.length === 0) {
-        throw new Error('Items not found')
-      } else {
-        return typedObjects
-      }
+      return storedObjects.map(function (storedObject) {
+        return (storedObject instanceof Error || typeFilter(type, storedObject))
+          ? storedObject
+          : handleIncorrectTypeError(type, storedObject)
+      })
     } else {
       if (storedObjects.type === type) {
         return storedObjects
       } else {
-        throw new Error('Item not found')
+        throw handleIncorrectTypeError(type, storedObjects)
       }
     }
   })
+}
+
+function handleIncorrectTypeError (type, storedObject) {
+  var errorMessage = 'Object with type "' + type + '" and id "' + storedObject.id + '" is missing'
+  var incorrectType = new Error(errorMessage)
+  incorrectType.name = 'Not found'
+  incorrectType.status = 404
+  return incorrectType
 }

--- a/lib/scoped/update-or-add.js
+++ b/lib/scoped/update-or-add.js
@@ -25,24 +25,20 @@ function updateOrAdd (type, api, idOrObjectOrArray, newObject) {
   })
 
   .catch(function () {
-    if (Array.isArray(idOrObjectOrArray)) {
-      newObject = idOrObjectOrArray
+    var id = toId(idOrObjectOrArray)
+
+    if (!id) {
+      throw new Error('Missing ID')
+    }
+
+    if (idOrObjectOrArray === id && !newObject) {
+      throw new Error('Missing ID')
+    }
+
+    if (typeof newObject === 'object') {
+      newObject.id = id
     } else {
-      var id = toId(idOrObjectOrArray)
-
-      if (!id) {
-        throw new Error('Missing ID')
-      }
-
-      if (idOrObjectOrArray === id && !newObject) {
-        throw new Error('Missing ID')
-      }
-
-      if (typeof newObject === 'object') {
-        newObject.id = id
-      } else {
-        newObject = idOrObjectOrArray
-      }
+      newObject = idOrObjectOrArray
     }
 
     return add(type, api, newObject)


### PR DESCRIPTION
Currently `find(arrayWithOutOfScopeItem)` ignores out-of-scope items when returning the array of items.  Instead, `find(...)` should return an 'Item not found' error in place of the out of scope items.

Closes #116.
