### PR TITLE
scoped store conflict with document type field should reject with TypeError

### DIFF
--- a/lib/scoped/add.js
+++ b/lib/scoped/add.js
@@ -1,8 +1,13 @@
 module.exports = add
 
 var addType = require('../utils/add-type')
+var checkType = require('../utils/check-scoped-type')
 
 function add (type, api, objects) {
+  if (checkType.isTypeError(objects, type)) {
+    return Promise.reject(new TypeError(checkType.createErrorMessage(type)))
+  }
+
   if (Array.isArray(objects)) {
     objects = objects.map(addType.bind(null, type))
   } else {

--- a/lib/scoped/find-or-add.js
+++ b/lib/scoped/find-or-add.js
@@ -3,8 +3,13 @@ module.exports = findOrAdd
 var toId = require('pouchdb-hoodie-api/utils/to-id')
 var find = require('./find')
 var add = require('./add')
+var checkType = require('../utils/check-scoped-type')
 
 function findOrAdd (type, api, idOrObjectOrArray, newObject) {
+  if (checkType.isTypeError(idOrObjectOrArray, type) || checkType.isTypeError(newObject, type)) {
+    return Promise.reject(new TypeError(checkType.createErrorMessage(type)))
+  }
+
   return find(type, api, idOrObjectOrArray)
 
   .then(function (typedObjects) {

--- a/lib/scoped/find.js
+++ b/lib/scoped/find.js
@@ -1,8 +1,13 @@
 module.exports = find
 
+var checkType = require('../utils/check-scoped-type')
 var typeFilter = require('../utils/type-filter')
 
 function find (type, api, objectsOrIds) {
+  if (checkType.isTypeError(objectsOrIds, type)) {
+    return Promise.reject(new TypeError(checkType.createErrorMessage(type)))
+  }
+
   return api.find(objectsOrIds)
 
   .then(function (storedObjects) {

--- a/lib/scoped/remove.js
+++ b/lib/scoped/remove.js
@@ -2,8 +2,13 @@ module.exports = remove
 
 var update = require('./update')
 var markAsDeleted = require('pouchdb-hoodie-api/utils/mark-as-deleted')
+var checkType = require('../utils/check-scoped-type')
 
 function remove (type, api, objectsOrIds, change) {
+  if (checkType.isTypeError(objectsOrIds, type) || checkType.isTypeError(change, type)) {
+    return Promise.reject(new TypeError(checkType.createErrorMessage(type)))
+  }
+
   return Array.isArray(objectsOrIds)
   ? update(type, api, objectsOrIds.map(markAsDeleted.bind(null, change)))
   : update(type, api, objectsOrIds, markAsDeleted(change, objectsOrIds))

--- a/lib/scoped/update-all.js
+++ b/lib/scoped/update-all.js
@@ -1,9 +1,14 @@
 module.exports = updateAll
 
+var checkType = require('../utils/check-scoped-type')
 var findAll = require('./find-all')
 var update = require('./update')
 
 function updateAll (type, api, changedProperties) {
+  if (checkType.isTypeError(changedProperties, type)) {
+    return Promise.reject(new TypeError(checkType.createErrorMessage(type)))
+  }
+
   return findAll(type, api)
 
   .then(function (foundObjects) {

--- a/lib/scoped/update-or-add.js
+++ b/lib/scoped/update-or-add.js
@@ -2,9 +2,14 @@ module.exports = updateOrAdd
 
 var update = require('./update')
 var add = require('./add')
+var checkType = require('../utils/check-scoped-type')
 var toId = require('pouchdb-hoodie-api/utils/to-id')
 
 function updateOrAdd (type, api, idOrObjectOrArray, newObject) {
+  if (checkType.isTypeError(idOrObjectOrArray, type) || checkType.isTypeError(newObject, type)) {
+    return Promise.reject(new TypeError(checkType.createErrorMessage(type)))
+  }
+
   return update(type, api, idOrObjectOrArray, newObject)
 
   .then(function (updatedItemsOrErrors) {

--- a/lib/scoped/update.js
+++ b/lib/scoped/update.js
@@ -3,7 +3,13 @@ module.exports = update
 var find = require('./find')
 var merge = require('lodash/merge')
 
+var checkType = require('../utils/check-scoped-type')
+
 function update (type, api, objectsOrIds, change) {
+  if (checkType.isTypeError(objectsOrIds, type) || checkType.isTypeError(change, type)) {
+    return Promise.reject(new TypeError(checkType.createErrorMessage(type)))
+  }
+
   return find(type, api, objectsOrIds)
 
   .then(function (storedObjects) {

--- a/lib/utils/check-scoped-type.js
+++ b/lib/utils/check-scoped-type.js
@@ -1,0 +1,13 @@
+module.exports = {
+  isTypeError: function (objects, type) {
+    if (Array.isArray(objects)) {
+      return objects.some(function (object) { object.type && object.type !== type })
+    }
+
+    return typeof objects === 'object' && objects.type && objects.type !== type
+  },
+
+  createErrorMessage: function (type) {
+    return 'type field in document does not match scoped store type of \'' + type + '\''
+  }
+}

--- a/tests/specs/scoped.js
+++ b/tests/specs/scoped.js
@@ -839,6 +839,63 @@ test('store.add should invoke store.on("add") and store.on("change") with event 
   .catch(t.fail)
 })
 
+test('scoped store methods with type conflict', function (t) {
+  t.plan(22)
+  var store = new Store('test-type-conflicts', merge({remote: 'test-type-conflicts'}, options))
+  var fooStore = store('foo')
+  var expectedMessage = 'type field in document does not match scoped store type of \'foo\''
+
+  function verifyError (methodType, error) {
+    t.true(error instanceof TypeError, 'TypeError on scoped .' + methodType + '() type conflict')
+    t.is(error.message, expectedMessage, 'correct error message is displayed')
+  }
+
+  fooStore.add({ type: 'bar' })
+    .then(t.fail)
+    .catch(verifyError.bind(null, 'add'))
+
+  fooStore.find({ type: 'bar' })
+    .then(t.fail)
+    .catch(verifyError.bind(null, 'find'))
+
+  fooStore.findOrAdd({ type: 'bar' })
+    .then(t.fail)
+    .catch(verifyError.bind(null, 'findOrAdd'))
+
+  fooStore.update({ type: 'bar' })
+    .then(t.fail)
+    .catch(verifyError.bind(null, 'update'))
+
+  fooStore.updateOrAdd({ type: 'bar' })
+    .then(t.fail)
+    .catch(verifyError.bind(null, 'updateOrAdd'))
+
+  fooStore.updateAll({ type: 'bar' })
+    .then(t.fail)
+    .catch(verifyError.bind(null, 'updateAll'))
+
+  fooStore.remove({ type: 'bar' })
+    .then(t.fail)
+    .catch(verifyError.bind(null, 'remove'))
+
+  // test second argument
+  fooStore.findOrAdd('abc123', { type: 'bar' })
+    .then(t.fail)
+    .catch(verifyError.bind(null, 'findOrAdd'))
+
+  fooStore.update('abc123', { type: 'bar' })
+    .then(t.fail)
+    .catch(verifyError.bind(null, 'update'))
+
+  fooStore.updateOrAdd('abc123', { type: 'bar' })
+    .then(t.fail)
+    .catch(verifyError.bind(null, 'updateOrAdd'))
+
+  fooStore.remove('abc123', { type: 'bar' })
+    .then(t.fail)
+    .catch(verifyError.bind(null, 'remove'))
+})
+
 // prepared for https://github.com/hoodiehq/camp/issues/30
 test.skip('scoped store.add should invoke store.on("add") and store.on("change") with event "add"', function (t) {
   t.plan(3)


### PR DESCRIPTION
The `type` field in a document is a reserved field use to store the scope of a document.  Therefore, in a scoped store, when a user attempts to add a document with a `type` field that conflicts with the name of the scope a `TypeError` should be raised.  The same goes for other operations (e.g. `find`, `update`, `remove`) where there is a conflict.

closes #129.
