### PR TITLE
refactor(utils) replace String.match with RegExp.test

### DIFF
--- a/lib/utils/isnt-design-doc.js
+++ b/lib/utils/isnt-design-doc.js
@@ -1,4 +1,4 @@
 // Checks for a design doc, so we can filters out docs that shouldn't return in *All methods
 module.exports = function isntDesignDoc (row) {
-  return row.id.match(/^_design/) === null
+  return /^_design/.test(row.id) !== true
 }


### PR DESCRIPTION
This PR is a follow up to https://github.com/hoodiehq/hoodie-store-client/pull/153#discussion_r124099406.

In some browsers `RegExp.prototype.test` is faster than `String.prototype.match`, especially if you only want to test if the regex matches the string and you are not interested in the actual matches.

@gr2m not sure if this PR is opened on the correct branch, please tell me if I need to correct something. 