### PR TITLE
Make public db a getter

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,9 @@ function Store (dbName, options) {
   }
 
   var api = {
-    db: state.db,
+    get db () {
+      return state.db
+    },
     isPersistent: require('./lib/is-persistent').bind(null, state),
     add: require('./lib/add').bind(null, state, null),
     find: require('./lib/find').bind(null, state, null),

--- a/tests/integration/reset.js
+++ b/tests/integration/reset.js
@@ -126,6 +126,37 @@ test('events work on scoped APIs after reset', function (t) {
   .catch(t.error)
 })
 
+test('.db works after reset (hoodiehq/hoodie-store-client#168)', function (t) {
+  t.plan(1)
+
+  var name = uniqueName()
+  var store = new Store(name, {
+    PouchDB: PouchDB,
+    remote: 'remote-' + name
+  })
+
+  store.reset()
+
+  .then(function () {
+    return store.db.put({
+      _id: 'test',
+      value: 42
+    })
+  })
+
+  .then(function () {
+    return store.db.allDocs({
+      include_docs: true
+    })
+  })
+
+  .then(function () {
+    t.pass('ok')
+  })
+
+  .catch(t.error)
+})
+
 test('emits "reset" event', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
Fixes #168.

Changes proposed in this pull request:
- Test if `.db` still works after a `reset`
- Change the global `.db` to be a getter