### PR TITLE
pull, push and sync error

### DIFF
--- a/lib/pull.js
+++ b/lib/pull.js
@@ -1,6 +1,7 @@
 module.exports = pull
 
 var Promise = require('lie')
+var errors = require('pouchdb-errors')
 
 var toId = require('./utils/to-id')
 
@@ -12,7 +13,6 @@ var toId = require('./utils/to-id')
  */
 function pull (state, docsOrIds) {
   var pulledObjects = []
-  var errors = state.db.constructor.Errors
 
   return Promise.resolve(state.remote)
 
@@ -25,7 +25,8 @@ function pull (state, docsOrIds) {
       }
 
       if (docsOrIds && docsOrIds.filter(Boolean).length !== docsOrIds.length) {
-        return Promise.reject(errors.NOT_AN_OBJECT)
+        reject(errors.NOT_AN_OBJECT)
+        return
       }
 
       var replication = state.db.replicate.from(remote, {

--- a/lib/push.js
+++ b/lib/push.js
@@ -1,6 +1,7 @@
 module.exports = push
 
 var Promise = require('lie')
+var errors = require('pouchdb-errors')
 
 var toId = require('./utils/to-id')
 
@@ -13,7 +14,6 @@ var toId = require('./utils/to-id')
 
 function push (state, docsOrIds) {
   var pushedObjects = []
-  var errors = state.db.constructor.Errors
 
   return Promise.resolve(state.remote)
 
@@ -26,7 +26,8 @@ function push (state, docsOrIds) {
       }
 
       if (docsOrIds && docsOrIds.filter(Boolean).length !== docsOrIds.length) {
-        return Promise.reject(errors.NOT_AN_OBJECT)
+        reject(errors.NOT_AN_OBJECT)
+        return
       }
 
       var replication = state.db.replicate.to(remote, {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,6 +1,7 @@
 module.exports = sync
 
 var Promise = require('lie')
+var errors = require('pouchdb-errors')
 
 var toId = require('./utils/to-id')
 
@@ -12,7 +13,6 @@ var toId = require('./utils/to-id')
  */
 function sync (state, docsOrIds) {
   var syncedObjects = []
-  var errors = state.db.constructor.Errors
 
   return Promise.resolve(state.remote)
 
@@ -25,7 +25,8 @@ function sync (state, docsOrIds) {
       }
 
       if (docsOrIds && docsOrIds.filter(Boolean).length !== docsOrIds.length) {
-        return Promise.reject(errors.NOT_AN_OBJECT)
+        reject(errors.NOT_AN_OBJECT)
+        return
       }
 
       var replication = state.db.sync(remote, {

--- a/tests/integration/pull.js
+++ b/tests/integration/pull.js
@@ -188,8 +188,8 @@ test('store.pull() when local / remote in sync', function (t) {
   })
 })
 
-test('store.pull(reject)', function (t) {
-  t.plan(2)
+test('store.pull({}) rejects', function (t) {
+  t.plan(5)
 
   var name = uniqueName()
   var remoteDb = new PouchDB('remote-' + name)
@@ -205,14 +205,17 @@ test('store.pull(reject)', function (t) {
   })
 
   .catch(function (error) {
-    t.pass(error.message)
+    t.is(error.status, 400, 'Rejects with not an NOT_AN_OBJECT status')
+    t.is(error.message, 'Document must be a JSON object', 'Rejects with not an NOT_AN_OBJECT')
   })
 
   .then(function () {
     return store.pull([1, 2, undefined])
   })
 
-  .catch(function () {
+  .catch(function (error) {
+    t.is(error.status, 400, 'Rejects with not an NOT_AN_OBJECT status')
+    t.is(error.message, 'Document must be a JSON object', 'Rejects with not an NOT_AN_OBJECT')
     t.pass('One object within the array is undefined')
   })
 })

--- a/tests/integration/push.js
+++ b/tests/integration/push.js
@@ -184,7 +184,7 @@ test('store.push() when local / remote in sync', function (t) {
 })
 
 test('store.push({}) rejects', function (t) {
-  t.plan(2)
+  t.plan(5)
 
   var name = uniqueName()
   var remoteDb = new PouchDB('remote-' + name)
@@ -203,14 +203,17 @@ test('store.push({}) rejects', function (t) {
   })
 
   .catch(function (error) {
-    t.pass(error.message)
+    t.is(error.status, 400, 'Rejects with not an NOT_AN_OBJECT status')
+    t.is(error.message, 'Document must be a JSON object', 'Rejects with not an NOT_AN_OBJECT')
   })
 
   .then(function () {
     return store.push([1, 2, undefined])
   })
 
-  .catch(function () {
+  .catch(function (error) {
+    t.is(error.status, 400, 'Rejects with not an NOT_AN_OBJECT status')
+    t.is(error.message, 'Document must be a JSON object', 'Rejects with not an NOT_AN_OBJECT')
     t.pass('One doc within the array is undefined')
   })
 })

--- a/tests/integration/sync.js
+++ b/tests/integration/sync.js
@@ -702,8 +702,8 @@ test('store.sync(), when local / remote in sync', function (t) {
   })
 })
 
-test('store.sync({})', function (t) {
-  t.plan(2)
+test('store.sync({}) rejects', function (t) {
+  t.plan(5)
 
   var name = uniqueName()
   var remoteDb = new PouchDB('remote-' + name)
@@ -728,14 +728,17 @@ test('store.sync({})', function (t) {
   })
 
   .catch(function (error) {
-    t.pass(error.message)
+    t.is(error.status, 400, 'Rejects with not an NOT_AN_OBJECT status')
+    t.is(error.message, 'Document must be a JSON object', 'Rejects with not an NOT_AN_OBJECT')
   })
 
   .then(function () {
     return store.sync([1, 2, undefined])
   })
 
-  .catch(function () {
+  .catch(function (error) {
+    t.is(error.status, 400, 'Rejects with not an NOT_AN_OBJECT status')
+    t.is(error.message, 'Document must be a JSON object', 'Rejects with not an NOT_AN_OBJECT')
     t.pass('One object within the array is undefined')
   })
 })


### PR DESCRIPTION
**Describe the bug**
`pull`, `push` and `sync` throw not an pouchdb-error, but because, in the error case, they try to access a field of a `undefined` variable.

**To Reproduce**
1. Try to `pull`, `push` or `sync` with objects without an `_id`.
2. `console.error` the error.
3. See error `TypeError: Cannot read property 'NOT_AN_OBJECT' of undefined` in the console.

**Expected behavior**
It should throw an PouchDb *NOT_AN_OBJECT* Error.

**Changes proposed in this pull request:**
- Use the already installed `pouchdb-errors` directly to throw `NOT_AN_OBJECT`. Change this in 
  - `pull`
  - `push`
  - `sync`
- Add tests to check if the correct error is thrown.